### PR TITLE
Adicionando mais de uma moeda ao jogo

### DIFF
--- a/app/Coin.hs
+++ b/app/Coin.hs
@@ -6,14 +6,18 @@ import GHC.Float (int2Float)
 
 import Map
 import Types
+import Player
 
 
-drawCoin :: Float -> Assets -> Coin -> Picture
-drawCoin cellSize [_, _, _, _, _, _, coin, _, _] ((x, y), _) =
+drawCoin :: Assets -> Float -> Coin -> Picture
+drawCoin [_, _, _, _, _, _, coin, _, _] cellSize ((x, y), _) =
     translate newX newY coin
     where
         newX = x * cellSize
         newY = y * cellSize
+
+drawCoins :: Coins -> Assets -> CellSize -> Picture
+drawCoins coins assets cellSize = pictures $ map (drawCoin assets cellSize) coins
 
 coinPrice :: Bool -> Int
 coinPrice True = 10
@@ -22,11 +26,15 @@ coinPrice False = 0
 generateRandom :: StdGen -> (Int, Int) -> (Int, StdGen)
 generateRandom seed range = uniformR range seed
 
-updateCoin :: Coin -> Coin
-updateCoin (pos, seed)
-    | isCellFree random = (random, ySeed)
-    | otherwise = updateCoin (pos, ySeed)
+updateCoins :: Coins -> Player -> Coins
+updateCoins coins player = map (updateCoin player) coins
+
+updateCoin :: Player -> Coin -> Coin
+updateCoin player (pos, seed)
+    | randomPosIsFree = (random, ySeed)
+    | otherwise = updateCoin player (pos, ySeed)
     where
         (x, xSeed) = generateRandom seed (0 :: Int, round (Map.mapaWidth-1))
         (y, ySeed) = generateRandom xSeed (0 :: Int, round (Map.mapaHeight-1))
+        randomPosIsFree = isCellFree random
         random = (int2Float x, -(int2Float y))

--- a/app/Game.hs
+++ b/app/Game.hs
@@ -13,31 +13,32 @@ import Coin
 
 
 drawGame :: Game -> Picture
-drawGame (cellSize, width, height, mapa, assets, player, ghosts, coin, score, state) = 
+drawGame (cellSize, width, height, mapa, assets, player, ghosts, coins, score, state) = 
     pictures $ dMap ++ [dPlayer] ++ [dGhost] ++ [dCoin] ++ [dScoreboard]
     where
         dMap = Map.drawMapa assets cellSize width mapa (0, 0)
         dPlayer = Player.drawPlayer assets cellSize player
-        dCoin = Coin.drawCoin cellSize assets coin
+        dCoin = Coin.drawCoins coins assets cellSize 
         dScoreboard = Scoreboard.drawScoreboard height score
         dGhost = Ghost.drawGhosts ghosts assets cellSize
 
 
 updateGame :: Float -> Game -> Game
-updateGame dt (cellSize, width, height, mapa, assets, player, ghosts, coin, score, state) = 
-    (cellSize, width, height, mapa, assets, uPlayer, uGhosts, uCoin, uScore, uState)
+updateGame dt (cellSize, width, height, mapa, assets, player, ghosts, coins, score, state) = 
+    (cellSize, width, height, mapa, assets, uPlayer, uGhosts, uCoins, uScore, uState)
     where
         uPlayer = Player.updatePlayer player
         uGhosts = Ghost.updateGhosts ghosts player
-        coinCollision = hasCollision uPlayer [fst coin]
+        coinCollision = hasCollision uPlayer uCoinsPositions
         uScore = score + 1 + coinPrice coinCollision
         uGhostsPositions = map (\(x, y, _, _) -> (x, y)) uGhosts
+        uCoinsPositions = map (\((x, y), _) -> (x, y)) coins
         uState
             | hasCollision player uGhostsPositions = END
             | otherwise = GAME
-        uCoin
-            | coinCollision = Coin.updateCoin coin
-            | otherwise = coin
+        uCoins
+            | coinCollision = Coin.updateCoins coins player
+            | otherwise = coins
 
 
 gameInputHandler :: Event -> Game -> Game

--- a/app/Startup.hs
+++ b/app/Startup.hs
@@ -5,7 +5,7 @@ import Graphics.Gloss.Interface.Pure.Game
 
 import Types
 import Map
-import System.Random (StdGen)
+import System.Random (StdGen, mkStdGen)
 
 title = "Pacman"
 
@@ -21,7 +21,13 @@ background  = black                     :: Color
 player      = ((13, 17), (1, 0), 0)     :: Player
 ghost       = (1, -1, -1, ASTAR)        :: Ghost
 ghosts      = [(1, -1, -1, ASTAR), (26, -1, -1, BFS), (26, -29, -1, DJK)] :: Ghosts
-coins       = (13, -11)
+coins       = [
+                ((13, -11), mkStdGen 777), 
+                ((21, -25), mkStdGen 888), 
+                ((12, -25), mkStdGen 555),
+                ((7, -6), mkStdGen 444),
+                ((6, -26), mkStdGen 222),
+                ((23, -5), mkStdGen 111)] :: Coins
 score       = 0
 
 
@@ -33,8 +39,10 @@ assetsName = ["wall", "gold", "diamond", "nether", "player", "orange-ghost", "co
 
 
 loadGame :: Assets -> State -> GameMode -> Algorithm -> StdGen -> Game
-loadGame assets state HARD _ coinSeed = (cellSize, width, height, Map.mapaAtual, assets, player, ghosts, (coins, coinSeed), score, state)
-loadGame assets state SOLO algo coinSeed = (cellSize, width, height, Map.mapaAtual, assets, player, [newGhost], (coins, coinSeed), score, state)
+loadGame assets state HARD _ coinSeed = 
+    (cellSize, width, height, Map.mapaAtual, assets, player, ghosts, coins, score, state)
+loadGame assets state SOLO algo coinSeed = 
+    (cellSize, width, height, Map.mapaAtual, assets, player, [newGhost], coins, score, state)
     where
         (gx, gy, s, _) = ghost
         newGhost = (gx, gy, s, algo)

--- a/app/Types.hs
+++ b/app/Types.hs
@@ -39,6 +39,7 @@ type Assets = [Picture]
 type Ghost = (Float, Float, Float, Algorithm)
 type Ghosts = [Ghost]
 type Coin = (Point, StdGen)
+type Coins = [Coin]
 type Score = Int
 
-type Game = (CellSize, Width, Height, Mapa, Assets, Player, Ghosts, Coin, Score, State)
+type Game = (CellSize, Width, Height, Mapa, Assets, Player, Ghosts, Coins, Score, State)


### PR DESCRIPTION
Adiciona 6 moedas iniciais ao jogo, a colisão com elas e o update/draw de mais de uma moeda.

Sempre que o usuário bate em uma moeda aumenta 10 na pontuação e embaralha as 6 moedas no mapa.